### PR TITLE
Add XQuartz library to LIBPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,16 @@ CFLAGS = -O3
 
 LIBS = -lX11 -lm 
 
-LIBPATH =
+# Checking LIBPATH
+#. (OS detecting makefile)[http://stackoverflow.com/questions/714100/os-detecting-makefile]
+UNAME_S := $(shell uname -s)
+# Darwin x86_64, with XQuartz(X11) libraries
+#. (XQuartz)[https://xquartz.macosforge.org/trac/wiki/DeveloperInfo]
+ifeq ($(UNAME_S),Darwin)
+  LIBPATH = -L/opt/X11/lib
+else
+  LIBPATH =
+endif
 
 
 all:	xbs.c


### PR DESCRIPTION
XQuartz library is in need to build on Mac OS X.
